### PR TITLE
[C20-5361] Sticky assignor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,72 @@
+def formattedBranchName = BRANCH_NAME.replaceAll('/', '::')
+
+def repoName = "relayr/kafka-python"
+
+node('jenkins-neokami-slave', {
+
+    dockerTag = "${env.BRANCH_NAME}_${env.BUILD_NUMBER}"
+
+    properties([
+            buildDiscarder(
+                    logRotator(
+                            artifactDaysToKeepStr: '',
+                            artifactNumToKeepStr: '20',
+                            daysToKeepStr: '',
+                            numToKeepStr: '20'
+                    )
+            ),
+            pipelineTriggers([[$class: 'GitHubPushTrigger']])
+    ])
+
+    timestamps {
+        withEnv(['FORMATTED_BRANCH_NAME=' + formattedBranchName,
+                 'BUILD_NUMBER=' + env.BUILD_NUMBER]) {
+
+            stage ('Preparing VirtualEnv') {
+                cleanWs()
+                checkout scm
+
+                if (!fileExists('.env')){
+                    echo 'Creating virtualenv ...'
+                    sh 'virtualenv -p python3.6 .env'
+                }
+            }
+
+            stage('Install') {
+                sh """
+                    ./.env/bin/pip install .[dev]
+                """
+            }
+
+            stage('Tests + Coverage') {
+                sh """
+                    . .env/bin/activate
+                    pytest -k 'not consumer_integration' --cov=kafka --cov-report xml
+                """
+            }
+
+//             stage('Distribute Wheel') {
+//                 // if not master, then substitute version with version-branch-build tag
+//                 if (env.BRANCH_NAME != "master") {
+//                     sh """
+//                         sed -i 's/_VERSION = "\\(.*\\)"/_VERSION = "\\1-${env.BRANCH_NAME}--build-${env.BUILD_NUMBER}"/g' setup.py
+//                     """
+//                 }
+//
+//                 sh """
+//                     . .env/bin/activate
+//                     python setup.py bdist_wheel
+//                 """
+//
+//                 archiveArtifacts artifacts: 'dist/*'
+//
+//                 sh """
+//                     . .env/bin/activate
+//                     pip install twine
+//                     twine upload --repository pypicloud --skip-existing dist/*
+//                 """
+//             }
+
+        }
+    }
+})

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ node('jenkins-neokami-slave', {
 
             stage('Install') {
                 sh """
-                    ./.env/bin/pip install .[dev]
+                    ./.env/bin/pip install .[test]
                 """
             }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,27 +45,27 @@ node('jenkins-neokami-slave', {
                 """
             }
 
-//             stage('Distribute Wheel') {
-//                 // if not master, then substitute version with version-branch-build tag
-//                 if (env.BRANCH_NAME != "master") {
-//                     sh """
-//                         sed -i 's/_VERSION = "\\(.*\\)"/_VERSION = "\\1-${env.BRANCH_NAME}--build-${env.BUILD_NUMBER}"/g' setup.py
-//                     """
-//                 }
-//
-//                 sh """
-//                     . .env/bin/activate
-//                     python setup.py bdist_wheel
-//                 """
-//
-//                 archiveArtifacts artifacts: 'dist/*'
-//
-//                 sh """
-//                     . .env/bin/activate
-//                     pip install twine
-//                     twine upload --repository pypicloud --skip-existing dist/*
-//                 """
-//             }
+            stage('Distribute Wheel') {
+                // if not master, then substitute version with version-branch-build tag
+                if (env.BRANCH_NAME != "master") {
+                    sh """
+                        sed -i 's/__version__ = "\\(.*\\)"/__version__ = "\\1-${env.BRANCH_NAME}--build-${env.BUILD_NUMBER}"/g' kafka/version.py
+                    """
+                }
+
+                sh """
+                    . .env/bin/activate
+                    python setup.py bdist_wheel
+                """
+
+                archiveArtifacts artifacts: 'dist/*'
+
+                sh """
+                    . .env/bin/activate
+                    pip install twine
+                    twine upload --repository pypicloud --skip-existing dist/*
+                """
+            }
 
         }
     }

--- a/kafka/coordinator/assignors/abstract.py
+++ b/kafka/coordinator/assignors/abstract.py
@@ -44,7 +44,7 @@ class AbstractPartitionAssignor(object):
         pass
 
     @abc.abstractmethod
-    def on_assignment(self, assignment):
+    def on_assignment(self, assignment, generation):
         """Callback that runs on each assignment.
 
         This method can be used to update internal state, if any, of the
@@ -52,5 +52,6 @@ class AbstractPartitionAssignor(object):
 
         Arguments:
             assignment (MemberAssignment): the member's assignment
+            generation (int): generation id
         """
         pass

--- a/kafka/coordinator/assignors/range.py
+++ b/kafka/coordinator/assignors/range.py
@@ -3,10 +3,9 @@ from __future__ import absolute_import
 import collections
 import logging
 
-from kafka.vendor import six
-
 from kafka.coordinator.assignors.abstract import AbstractPartitionAssignor
 from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata, ConsumerProtocolMemberAssignment
+from kafka.vendor import six
 
 log = logging.getLogger(__name__)
 
@@ -73,5 +72,5 @@ class RangePartitionAssignor(AbstractPartitionAssignor):
         return ConsumerProtocolMemberMetadata(cls.version, list(topics), b'')
 
     @classmethod
-    def on_assignment(cls, assignment):
+    def on_assignment(cls, assignment, generation):
         pass

--- a/kafka/coordinator/assignors/range.py
+++ b/kafka/coordinator/assignors/range.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 import collections
 import logging
 
+from kafka.vendor import six
+
 from kafka.coordinator.assignors.abstract import AbstractPartitionAssignor
 from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata, ConsumerProtocolMemberAssignment
-from kafka.vendor import six
 
 log = logging.getLogger(__name__)
 

--- a/kafka/coordinator/assignors/roundrobin.py
+++ b/kafka/coordinator/assignors/roundrobin.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import collections
 import itertools
 import logging
+from typing import Optional
 
 from kafka.vendor import six
 
@@ -92,5 +93,5 @@ class RoundRobinPartitionAssignor(AbstractPartitionAssignor):
         return ConsumerProtocolMemberMetadata(cls.version, list(topics), b'')
 
     @classmethod
-    def on_assignment(cls, assignment):
+    def on_assignment(cls, assignment, generation):
         pass

--- a/kafka/coordinator/assignors/roundrobin.py
+++ b/kafka/coordinator/assignors/roundrobin.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import collections
 import itertools
 import logging
-from typing import Optional
 
 from kafka.vendor import six
 

--- a/kafka/coordinator/assignors/sticky/partition_movements.py
+++ b/kafka/coordinator/assignors/sticky/partition_movements.py
@@ -1,0 +1,140 @@
+import logging
+from collections import defaultdict
+from copy import deepcopy
+from typing import Dict, Set, List, Tuple, NamedTuple
+
+from kafka.structs import TopicPartition
+
+log = logging.getLogger(__name__)
+
+
+class ConsumerPair(NamedTuple):
+    """
+    Represents a pair of Kafka consumer ids involved in a partition reassignment.
+    Each ConsumerPair corresponds to a particular partition or topic, indicates that the particular partition or some
+    partition of the particular topic was moved from the source consumer to the destination consumer
+    during the rebalance. This class helps in determining whether a partition reassignment results in cycles among
+    the generated graph of consumer pairs.
+    """
+    src_member_id: str
+    dst_member_id: str
+
+
+def is_sublist(source: List, target: Tuple) -> bool:
+    """
+    :param source: the list in which to search for the occurrence of target.
+    :param target: the list to search for as a subList of source
+    :return: true if target is in source; false otherwise
+    """
+    for index in (i for i, e in enumerate(source) if e == target[0]):
+        if source[index : index + len(target)] == target:
+            return True
+    return False
+
+
+class PartitionMovements:
+    """
+    This class maintains some data structures to simplify lookup of partition movements among consumers.
+    At each point of time during a partition rebalance it keeps track of partition movements
+    corresponding to each topic, and also possible movement (in form a ConsumerPair object) for each partition.
+    """
+
+    def __init__(self):
+        self.partition_movements_by_topic: Dict[str, Dict[ConsumerPair, Set[TopicPartition]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
+        self.partition_movements: Dict[TopicPartition, ConsumerPair] = {}
+
+    def remove_movement_record_of_partition(self, partition: TopicPartition) -> ConsumerPair:
+        pair = self.partition_movements[partition]
+        del self.partition_movements[partition]
+        self.partition_movements_by_topic[partition.topic][pair].remove(partition)
+
+        return pair
+
+    def add_partition_movement_record(self, partition: TopicPartition, pair: ConsumerPair):
+        self.partition_movements[partition] = pair
+        self.partition_movements_by_topic[partition.topic][pair].add(partition)
+
+    def move_partition(self, partition: TopicPartition, old_consumer: str, new_consumer: str):
+        pair = ConsumerPair(src_member_id=old_consumer, dst_member_id=new_consumer)
+        if partition in self.partition_movements:
+            # this partition has previously moved
+            existing_pair = self.remove_movement_record_of_partition(partition)
+            assert existing_pair.dst_member_id == old_consumer
+            if existing_pair.src_member_id != new_consumer:
+                # the partition is not moving back to its previous consumer
+                self.add_partition_movement_record(
+                    partition, ConsumerPair(src_member_id=existing_pair.src_member_id, dst_member_id=new_consumer)
+                )
+        else:
+            self.add_partition_movement_record(partition, pair)
+
+    def get_partition_to_be_moved(self, partition: TopicPartition, old_consumer: str, new_consumer: str):
+        if partition.topic not in self.partition_movements_by_topic:
+            return partition
+        if partition in self.partition_movements:
+            # this partition has previously moved
+            assert old_consumer == self.partition_movements[partition].dst_member_id
+            old_consumer = self.partition_movements[partition].src_member_id
+        reverse_pair = ConsumerPair(src_member_id=new_consumer, dst_member_id=old_consumer)
+        if reverse_pair not in self.partition_movements_by_topic[partition.topic]:
+            return partition
+
+        return self.partition_movements_by_topic[partition.topic][reverse_pair].pop()
+
+    def is_sticky(self) -> bool:
+        for topic, movements in self.partition_movements_by_topic.items():
+            movement_pairs = set(movements.keys())
+            if self.has_cycles(movement_pairs):
+                log.error(
+                    f"Stickiness is violated for topic {topic}\n"
+                    f"Partition movements for this topic occurred among the following consumer pairs:\n"
+                    f"{movement_pairs}"
+                )
+                return False
+        return True
+
+    def has_cycles(self, consumer_pairs: Set[ConsumerPair]):
+        cycles = set()
+        for pair in consumer_pairs:
+            reduced_pairs = deepcopy(consumer_pairs)
+            reduced_pairs.remove(pair)
+            path = [pair.src_member_id]
+            if self.is_linked(pair.dst_member_id, pair.src_member_id, reduced_pairs, path) and self.is_subcycle(
+                path, cycles
+            ):
+                cycles.add(tuple(path))
+                log.error(f"A cycle of length {len(path) - 1} was found: {path}")
+
+        # for now we want to make sure there is no partition movements of the same topic between a pair of consumers.
+        # the odds of finding a cycle among more than two consumers seem to be very low (according to various randomized
+        # tests with the given sticky algorithm) that it should not worth the added complexity of handling those cases.
+        for cycle in cycles:
+            if len(cycle) == 3:  # indicates a cycle of length 2
+                return True
+        return False
+
+    def is_subcycle(self, cycle: List[str], cycles: Set[Tuple[str]]) -> bool:
+        super_cycle = deepcopy(cycle)
+        super_cycle = super_cycle[:-1]
+        super_cycle.extend(cycle)
+        for found_cycle in cycles:
+            if len(found_cycle) == len(cycle) and is_sublist(super_cycle, found_cycle):
+                return True
+        return False
+
+    def is_linked(self, src: str, dst: str, pairs: Set[ConsumerPair], current_path: List[str]):
+        if src == dst:
+            return False
+        if not pairs:
+            return False
+        if ConsumerPair(src, dst) in pairs:
+            return True
+        for pair in pairs:
+            if pair.src_member_id == src:
+                reduced_set = deepcopy(pairs)
+                reduced_set.remove(pair)
+                current_path.append(pair.src_member_id)
+                return self.is_linked(pair.dst_member_id, dst, reduced_set, current_path)
+        return False

--- a/kafka/coordinator/assignors/sticky/partition_movements.py
+++ b/kafka/coordinator/assignors/sticky/partition_movements.py
@@ -21,10 +21,14 @@ class ConsumerPair(NamedTuple):
 
 
 def is_sublist(source: List, target: Tuple) -> bool:
-    """
-    :param source: the list in which to search for the occurrence of target.
-    :param target: the list to search for as a subList of source
-    :return: true if target is in source; false otherwise
+    """Checks if one list is a sublist of another.
+
+    Arguments:
+      source: the list in which to search for the occurrence of target.
+      target: the list to search for as a sublist of source
+
+    Returns:
+      true if target is in source; false otherwise
     """
     for index in (i for i, e in enumerate(source) if e == target[0]):
         if source[index : index + len(target)] == target:

--- a/kafka/coordinator/assignors/sticky/partition_movements.py
+++ b/kafka/coordinator/assignors/sticky/partition_movements.py
@@ -31,7 +31,7 @@ def is_sublist(source: List, target: Tuple) -> bool:
       true if target is in source; false otherwise
     """
     for index in (i for i, e in enumerate(source) if e == target[0]):
-        if source[index: index + len(target)] == target:
+        if tuple(source[index: index + len(target)]) == target:
             return True
     return False
 

--- a/kafka/coordinator/assignors/sticky/sticky_assignor.py
+++ b/kafka/coordinator/assignors/sticky/sticky_assignor.py
@@ -33,12 +33,9 @@ def has_identical_list_elements(list_: List[List]) -> bool:
     """
     if not list_:
         return True
-    prev_element = list_[0]
     for i in range(1, len(list_)):
-        element = list_[i]
-        if element != prev_element:
+        if list_[i] != list_[i - 1]:
             return False
-        prev_element = element
     return True
 
 

--- a/kafka/coordinator/assignors/sticky/sticky_assignor.py
+++ b/kafka/coordinator/assignors/sticky/sticky_assignor.py
@@ -582,7 +582,7 @@ class StickyPartitionAssignor(AbstractPartitionAssignor):
     DEFAULT_GENERATION_ID = -1
 
     name = "sticky"
-    version = 1
+    version = 0
 
     member_assignment: List[TopicPartition] = None
     generation: int = DEFAULT_GENERATION_ID

--- a/kafka/coordinator/assignors/sticky/sticky_assignor.py
+++ b/kafka/coordinator/assignors/sticky/sticky_assignor.py
@@ -1,0 +1,668 @@
+import logging
+from collections import defaultdict
+from copy import deepcopy
+from typing import List, Dict, NamedTuple, Set, Tuple
+
+from sortedcontainers import SortedSet, SortedDict
+
+from kafka.cluster import ClusterMetadata
+from kafka.coordinator.assignors.abstract import AbstractPartitionAssignor
+from kafka.coordinator.assignors.sticky.partition_movements import PartitionMovements
+from kafka.coordinator.protocol import ConsumerProtocolMemberMetadata, ConsumerProtocolMemberAssignment
+from kafka.coordinator.protocol import Schema
+from kafka.protocol.struct import Struct
+from kafka.protocol.types import String, Array, Int32
+from kafka.structs import TopicPartition
+
+log = logging.getLogger(__name__)
+
+
+class ConsumerGenerationPair(NamedTuple):
+    consumer: str
+    generation: int
+
+
+def has_identical_list_elements(list_: List[List]) -> bool:
+    """
+    :param list_: collection of lists
+    :return: true if all lists in the collection have the same members; false otherwise
+    """
+    if not list_:
+        return True
+    prev_element = list_[0]
+    for i in range(1, len(list_)):
+        element = list_[i]
+        if element != prev_element:
+            return False
+        prev_element = element
+    return True
+
+
+def subscriptions_comparator_key(element: Tuple[str, Tuple[TopicPartition]]) -> Tuple[int, str]:
+    return len(element[1]), element[0]
+
+
+def partitions_comparator_key(element: Tuple[TopicPartition, Tuple[str]]) -> Tuple[int, str, int]:
+    return len(element[1]), element[0].topic, element[0].partition
+
+
+def remove_if_present(collection, element):
+    try:
+        collection.remove(element)
+    except (ValueError, KeyError):
+        pass
+
+
+class StickyAssignorMemberMetadataV1(NamedTuple):
+    subscription: List[str]
+    partitions: List[TopicPartition]
+    generation: int
+
+
+class StickyAssignorUserDataV1(Struct):
+    """
+    Used for preserving consumer's previously assigned partitions
+    list and sending it as user data to the leader during a rebalance
+    """
+
+    SCHEMA = Schema(
+        ("previous_assignment", Array(("topic", String("utf-8")), ("partitions", Array(Int32)))), ("generation", Int32)
+    )
+
+
+class StickyAssignmentExecutor:
+    def __init__(self, cluster: ClusterMetadata, members: Dict[str, StickyAssignorMemberMetadataV1]):
+        self.members = members
+        # a mapping between consumers and their assigned partitions that is updated during assignment procedure
+        self.current_assignment: Dict[str, List[TopicPartition]] = defaultdict(list)
+        # an assignment from a previous generation
+        self.previous_assignment: Dict[TopicPartition, ConsumerGenerationPair] = {}
+        # a mapping between partitions and their assigned consumers
+        self.current_partition_consumer: Dict[TopicPartition, str] = {}
+        # a flag indicating that there were no previous assignments performed ever
+        self.is_fresh_assignment = False
+        # a mapping of all topic partitions to all consumers that can be assigned to them
+        self.partition2all_potential_consumers: Dict[TopicPartition, List[str]] = {}
+        # a mapping of all consumers to all potential topic partitions that can be assigned to them
+        self.consumer2all_potential_partitions: Dict[str, List[TopicPartition]] = {}
+
+        # an ascending sorted set of consumers based on how many topic partitions are already assigned to them
+        self.sorted_current_subscriptions: Set[Tuple[str, Tuple[TopicPartition]]] = set()
+        # an ascending sorted list of topic partitions based on how many consumers can potentially use them
+        self.sorted_partitions: List[TopicPartition] = []
+        # all partitions that need to be assigned
+        self.unassigned_partitions: List[TopicPartition] = []
+        # a flag indicating that a certain partition cannot remain assigned to its current consumer because the consumer
+        # is no longer subscribed to its topic
+        self.revocation_required = False
+
+        self.partition_movements = PartitionMovements()
+        self._init(cluster)
+
+    def perform_initial_assignment(self):
+        self._populate_sorted_partitions()
+        self._populate_partitions_to_reassign()
+
+    def balance(self):
+        self._initialize_current_subscriptions()
+        initializing = len(self.current_assignment[self._get_consumer_with_most_subscriptions()]) == 0
+
+        # assign all unassigned partitions
+        for partition in self.unassigned_partitions:
+            # skip if there is no potential consumer for the partition
+            if not self.partition2all_potential_consumers[partition]:
+                continue
+            self._assign_partition(partition)
+
+        # narrow down the reassignment scope to only those partitions that can actually be reassigned
+        fixed_partitions: Set[TopicPartition] = set()
+        for partition in self.partition2all_potential_consumers.keys():
+            if not self._can_partition_participate_in_reassignment(partition):
+                fixed_partitions.add(partition)
+        for fixed_partition in fixed_partitions:
+            remove_if_present(self.sorted_partitions, fixed_partition)
+            remove_if_present(self.unassigned_partitions, fixed_partition)
+
+        # narrow down the reassignment scope to only those consumers that are subject to reassignment
+        fixed_assignments: Dict[str, List[TopicPartition]] = {}
+        for consumer in self.consumer2all_potential_partitions.keys():
+            if not self._can_consumer_participate_in_reassignment(consumer):
+                self._remove_consumer_from_current_subscriptions_and_maintain_order(consumer)
+                fixed_assignments[consumer] = self.current_assignment[consumer]
+                del self.current_assignment[consumer]
+
+        # create a deep copy of the current assignment so we can revert to it
+        # if we do not get a more balanced assignment later
+        prebalance_assignment = deepcopy(self.current_assignment)
+        prebalance_partition_consumers = deepcopy(self.current_partition_consumer)
+
+        # if we don't already need to revoke something due to subscription changes,
+        # first try to balance by only moving newly added partitions
+        if not self.revocation_required:
+            self._perform_reassignments(self.unassigned_partitions)
+        reassignment_performed = self._perform_reassignments(self.sorted_partitions)
+
+        # if we are not preserving existing assignments and we have made changes to the current assignment
+        # make sure we are getting a more balanced assignment; otherwise, revert to previous assignment
+        if (
+            not initializing
+            and reassignment_performed
+            and self._get_balance_score(self.current_assignment) >= self._get_balance_score(prebalance_assignment)
+        ):
+            self.current_assignment = prebalance_assignment
+            self.current_partition_consumer.clear()
+            self.current_partition_consumer.update(prebalance_partition_consumers)
+
+        # add the fixed assignments (those that could not change) back
+        for consumer, partitions in fixed_assignments.items():
+            self.current_assignment[consumer] = partitions
+            self._add_consumer_to_current_subscriptions_and_maintain_order(consumer)
+
+    def get_final_assignment(self, member_id) -> List[Tuple[str, List[int]]]:
+        assignment: Dict[str, List[int]] = defaultdict(list)
+        for topic_partition in self.current_assignment[member_id]:
+            assignment[topic_partition.topic].append(topic_partition.partition)
+        # noinspection PyTypeChecker
+        return list(assignment.items())
+
+    def _init(self, cluster: ClusterMetadata):
+        self._init_current_assignments(self.members)
+
+        for topic in cluster.topics():
+            partitions = cluster.partitions_for_topic(topic)
+            if partitions is None:
+                log.warning("No partition metadata for topic %s", topic)
+                continue
+            for p in partitions:
+                partition = TopicPartition(topic=topic, partition=p)
+                self.partition2all_potential_consumers[partition] = []
+        for consumer_id, member_metadata in self.members.items():
+            self.consumer2all_potential_partitions[consumer_id] = []
+            for topic in member_metadata.subscription:
+                if cluster.partitions_for_topic(topic) is None:
+                    log.warning(f"No partition metadata for topic {topic}")
+                    continue
+                for p in cluster.partitions_for_topic(topic):
+                    partition = TopicPartition(topic=topic, partition=p)
+                    self.consumer2all_potential_partitions[consumer_id].append(partition)
+                    self.partition2all_potential_consumers[partition].append(consumer_id)
+            if consumer_id not in self.current_assignment:
+                self.current_assignment[consumer_id] = []
+
+    def _init_current_assignments(self, members: Dict[str, StickyAssignorMemberMetadataV1]):
+        # we need to process subscriptions' user data with each consumer's reported generation in mind
+        # higher generations overwrite lower generations in case of a conflict
+        # note that a conflict could exists only if user data is for different generations
+
+        # for each partition we create a sorted map of its consumers by generation
+        sorted_partition_consumers_by_generation: Dict[TopicPartition, SortedDict[int, str]] = {}
+        for consumer, member_metadata in members.items():
+            for partitions in member_metadata.partitions:
+                if partitions in sorted_partition_consumers_by_generation:
+                    consumers: Dict[int, str] = sorted_partition_consumers_by_generation[partitions]
+                    if member_metadata.generation and member_metadata.generation in consumers:
+                        # same partition is assigned to two consumers during the same rebalance.
+                        # log a warning and skip this record
+                        log.warning(
+                            f"Partition {partitions} is assigned to multiple consumers "
+                            f"following sticky assignment generation {member_metadata.generation}."
+                        )
+                    else:
+                        consumers[member_metadata.generation] = consumer
+                else:
+                    sorted_consumers = SortedDict()
+                    sorted_consumers[member_metadata.generation] = consumer
+                    sorted_partition_consumers_by_generation[partitions] = sorted_consumers
+
+        # previous_assignment holds the prior ConsumerGenerationPair (before current) of each partition
+        # current and previous consumers are the last two consumers of each partition in the above sorted map
+        for partitions, consumers in sorted_partition_consumers_by_generation.items():
+            generations = list(reversed(consumers.keys()))
+            self.current_assignment[consumers[generations[0]]].append(partitions)
+            # now update previous assignment if any
+            if len(generations) > 1:
+                self.previous_assignment[partitions] = ConsumerGenerationPair(
+                    consumer=consumers[generations[1]], generation=generations[1]
+                )
+
+        self.is_fresh_assignment = len(self.current_assignment) == 0
+
+        for consumer_id, partitions in self.current_assignment.items():
+            for partition in partitions:
+                self.current_partition_consumer[partition] = consumer_id
+
+    def _are_subscriptions_identical(self) -> bool:
+        """
+        :return: true if potential consumers of partitions are the same, and potential partitions consumers can
+        consume from are the same too
+        """
+        if not has_identical_list_elements(list(self.partition2all_potential_consumers.values())):
+            return False
+        return has_identical_list_elements(list(self.consumer2all_potential_partitions.values()))
+
+    def _populate_sorted_partitions(self):
+        # an ascending sorted set of topic partitions based on how many consumers can potentially use them
+        sorted_all_partitions: SortedSet[Tuple[TopicPartition, List[str]]] = SortedSet(
+            iterable=[(tp, tuple(consumers)) for tp, consumers in self.partition2all_potential_consumers.items()],
+            key=partitions_comparator_key,
+        )
+
+        self.sorted_partitions = []
+        if not self.is_fresh_assignment and self._are_subscriptions_identical():
+            # if this is a reassignment and the subscriptions are identical (all consumers can consumer from all topics)
+            # then we just need to simply list partitions in a round robin fashion (from consumers with
+            # most assigned partitions to those with least)
+            assignments = deepcopy(self.current_assignment)
+            for consumer_id, partitions in assignments.items():
+                to_remove = []
+                for partition in partitions:
+                    if partition not in self.partition2all_potential_consumers:
+                        to_remove.append(partition)
+                for partition in to_remove:
+                    partitions.remove(partition)
+
+            sorted_consumers: SortedSet[Tuple[str, Tuple[TopicPartition]]] = SortedSet(
+                iterable=[(consumer, tuple(partitions)) for consumer, partitions in assignments.items()],
+                key=subscriptions_comparator_key,
+            )
+            # at this point, sorted_consumers contains an ascending-sorted list of consumers based on
+            # how many valid partitions are currently assigned to them
+            while sorted_consumers:
+                # take the consumer with the most partitions
+                consumer, _ = sorted_consumers.pop()
+                # currently assigned partitions to this consumer
+                remaining_partitions = assignments[consumer]
+                # from partitions that had a different consumer before,
+                # keep only those that are assigned to this consumer now
+                previous_partitions = set(self.previous_assignment.keys()).intersection(set(remaining_partitions))
+                if previous_partitions:
+                    # if there is a partition of this consumer that was assigned to another consumer before
+                    # mark it as good options for reassignment
+                    partition = previous_partitions.pop()
+                    remaining_partitions.remove(partition)
+                    self.sorted_partitions.append(partition)
+                    sorted_consumers.add((consumer, tuple(assignments[consumer])))
+                elif remaining_partitions:
+                    # otherwise, mark any other one of the current partitions as a reassignment candidate
+                    self.sorted_partitions.append(remaining_partitions.pop())
+                    sorted_consumers.add((consumer, tuple(assignments[consumer])))
+
+            while sorted_all_partitions:
+                partition = sorted_all_partitions.pop(0)[0]
+                if partition not in self.sorted_partitions:
+                    self.sorted_partitions.append(partition)
+        else:
+            while sorted_all_partitions:
+                self.sorted_partitions.append(sorted_all_partitions.pop(0)[0])
+
+    def _populate_partitions_to_reassign(self):
+        self.unassigned_partitions = deepcopy(self.sorted_partitions)
+
+        assignments_to_remove = []
+        for consumer_id, partitions in self.current_assignment.items():
+            if consumer_id not in self.members:
+                # if a consumer that existed before (and had some partition assignments) is now removed,
+                # remove it from current_assignment
+                for partition in partitions:
+                    del self.current_partition_consumer[partition]
+                assignments_to_remove.append(consumer_id)
+            else:
+                # otherwise (the consumer still exists)
+                partitions_to_remove = []
+                for partition in partitions:
+                    if partition not in self.partition2all_potential_consumers:
+                        # if this topic partition of this consumer no longer exists
+                        # remove it from current_assignment of the consumer
+                        partitions_to_remove.append(partition)
+                    elif partition.topic not in self.members[consumer_id].subscription:
+                        # if this partition cannot remain assigned to its current consumer because the consumer
+                        # is no longer subscribed to its topic remove it from current_assignment of the consumer
+                        partitions_to_remove.append(partition)
+                        self.revocation_required = True
+                    else:
+                        # otherwise, remove the topic partition from those that need to be assigned only if
+                        # its current consumer is still subscribed to its topic (because it is already assigned
+                        # and we would want to preserve that assignment as much as possible)
+                        self.unassigned_partitions.remove(partition)
+                for partition in partitions_to_remove:
+                    self.current_assignment[consumer_id].remove(partition)
+                    del self.current_partition_consumer[partition]
+        for consumer_id in assignments_to_remove:
+            del self.current_assignment[consumer_id]
+
+    def _initialize_current_subscriptions(self):
+        self.sorted_current_subscriptions = SortedSet(
+            iterable=[(consumer, tuple(partitions)) for consumer, partitions in self.current_assignment.items()],
+            key=subscriptions_comparator_key,
+        )
+
+    def _get_consumer_with_least_subscriptions(self) -> str:
+        return self.sorted_current_subscriptions[0][0]
+
+    def _get_consumer_with_most_subscriptions(self) -> str:
+        return self.sorted_current_subscriptions[-1][0]
+
+    def _remove_consumer_from_current_subscriptions_and_maintain_order(self, consumer: str):
+        self.sorted_current_subscriptions.remove((consumer, tuple(self.current_assignment[consumer])))
+
+    def _add_consumer_to_current_subscriptions_and_maintain_order(self, consumer: str):
+        self.sorted_current_subscriptions.add((consumer, tuple(self.current_assignment[consumer])))
+
+    def _is_balanced(self) -> bool:
+        """
+        Determines if the current assignment is a balanced one
+        """
+        if (
+            len(self.current_assignment[self._get_consumer_with_least_subscriptions()])
+            >= len(self.current_assignment[self._get_consumer_with_most_subscriptions()]) - 1
+        ):
+            # if minimum and maximum numbers of partitions assigned to consumers differ by at most one return true
+            return True
+
+        # create a mapping from partitions to the consumer assigned to them
+        all_assigned_partitions: Dict[TopicPartition, str] = {}
+        for consumer_id, consumer_partitions in self.current_assignment.items():
+            for partition in consumer_partitions:
+                if partition in all_assigned_partitions:
+                    log.error(f"{partition} is assigned to more than one consumer.")
+                all_assigned_partitions[partition] = consumer_id
+
+        # for each consumer that does not have all the topic partitions it can get
+        # make sure none of the topic partitions it could but did not get cannot be moved to it
+        # (because that would break the balance)
+        for consumer, _ in self.sorted_current_subscriptions:
+            consumer_partition_count = len(self.current_assignment[consumer])
+            # skip if this consumer already has all the topic partitions it can get
+            if consumer_partition_count == len(self.consumer2all_potential_partitions[consumer]):
+                continue
+
+            # otherwise make sure it cannot get any more
+            for partition in self.consumer2all_potential_partitions[consumer]:
+                if partition not in self.current_assignment[consumer]:
+                    other_consumer = all_assigned_partitions[partition]
+                    other_consumer_partition_count = len(self.current_assignment[other_consumer])
+                    if consumer_partition_count < other_consumer_partition_count:
+                        return False
+        return True
+
+    def _assign_partition(self, partition: TopicPartition):
+        for consumer, _ in self.sorted_current_subscriptions:
+            if partition in self.consumer2all_potential_partitions[consumer]:
+                self._remove_consumer_from_current_subscriptions_and_maintain_order(consumer)
+                self.current_assignment[consumer].append(partition)
+                self.current_partition_consumer[partition] = consumer
+                self._add_consumer_to_current_subscriptions_and_maintain_order(consumer)
+                break
+
+    def _can_partition_participate_in_reassignment(self, partition: TopicPartition) -> bool:
+        return len(self.partition2all_potential_consumers[partition]) >= 2
+
+    def _can_consumer_participate_in_reassignment(self, consumer: str) -> bool:
+        current_partitions = self.current_assignment[consumer]
+        current_assignment_size = len(current_partitions)
+        max_assignment_size = len(self.consumer2all_potential_partitions[consumer])
+        if current_assignment_size > max_assignment_size:
+            log.error(f"The consumer {consumer} is assigned more partitions than the maximum possible.")
+        if current_assignment_size < max_assignment_size:
+            # if a consumer is not assigned all its potential partitions it is subject to reassignment
+            return True
+        for partition in current_partitions:
+            # if any of the partitions assigned to a consumer is subject to reassignment the consumer itself
+            # is subject to reassignment
+            if self._can_partition_participate_in_reassignment(partition):
+                return True
+        return False
+
+    def _perform_reassignments(self, reassignable_partitions: List[TopicPartition]) -> bool:
+        reassignment_performed = False
+
+        # repeat reassignment until no partition can be moved to improve the balance
+        while True:
+            modified = False
+            # reassign all reassignable partitions until the full list is processed or a balance is achieved
+            # (starting from the partition with least potential consumers and if needed)
+            for partition in reassignable_partitions:
+                if self._is_balanced():
+                    break
+                # the partition must have at least two consumers
+                if len(self.partition2all_potential_consumers[partition]) <= 1:
+                    log.error(f"Expected more than one potential consumer for partition {partition}")
+                # the partition must have a current consumer
+                consumer = self.current_partition_consumer.get(partition)
+                if consumer is None:
+                    log.error(f"Expected partition {partition} to be assigned to a consumer")
+
+                if (
+                    partition in self.previous_assignment
+                    and len(self.current_assignment[consumer])
+                    > len(self.current_assignment[self.previous_assignment[partition].consumer]) + 1
+                ):
+                    self._reassign_partition_to_consumer(
+                        partition, self.previous_assignment[partition].consumer,
+                    )
+                    reassignment_performed = True
+                    modified = True
+                    continue
+
+                # check if a better-suited consumer exist for the partition; if so, reassign it
+                for other_consumer in self.partition2all_potential_consumers[partition]:
+                    if len(self.current_assignment[consumer]) > len(self.current_assignment[other_consumer]) + 1:
+                        self._reassign_partition(partition)
+                        reassignment_performed = True
+                        modified = True
+                        break
+
+            if not modified:
+                break
+        return reassignment_performed
+
+    def _reassign_partition(self, partition: TopicPartition):
+        new_consumer = None
+        for another_consumer, _ in self.sorted_current_subscriptions:
+            if partition in self.consumer2all_potential_partitions[another_consumer]:
+                new_consumer = another_consumer
+                break
+        assert new_consumer is not None
+        self._reassign_partition_to_consumer(partition, new_consumer)
+
+    def _reassign_partition_to_consumer(self, partition: TopicPartition, new_consumer: str):
+        consumer = self.current_partition_consumer[partition]
+        # find the correct partition movement considering the stickiness requirement
+        partition_to_be_moved = self.partition_movements.get_partition_to_be_moved(partition, consumer, new_consumer)
+        self._move_partition(partition_to_be_moved, new_consumer)
+
+    def _move_partition(self, partition: TopicPartition, new_consumer: str):
+        old_consumer = self.current_partition_consumer[partition]
+        self._remove_consumer_from_current_subscriptions_and_maintain_order(old_consumer)
+        self._remove_consumer_from_current_subscriptions_and_maintain_order(new_consumer)
+
+        self.partition_movements.move_partition(partition, old_consumer, new_consumer)
+
+        self.current_assignment[old_consumer].remove(partition)
+        self.current_assignment[new_consumer].append(partition)
+        self.current_partition_consumer[partition] = new_consumer
+
+        self._add_consumer_to_current_subscriptions_and_maintain_order(new_consumer)
+        self._add_consumer_to_current_subscriptions_and_maintain_order(old_consumer)
+
+    @staticmethod
+    def _get_balance_score(assignment: Dict[str, List[TopicPartition]]) -> int:
+        """
+        :return: the balance score of the given assignment,
+        as the sum of assigned partitions size difference of all consumer pairs.
+        A perfectly balanced assignment (with all consumers getting the same number of partitions)
+        has a balance score of 0. Lower balance score indicates a more balanced assignment.
+        """
+        score = 0
+        consumer2assignment: Dict[str, int] = {}
+        for consumer_id, partitions in assignment.items():
+            consumer2assignment[consumer_id] = len(partitions)
+
+        consumers_to_explore = set(consumer2assignment.keys())
+        for consumer_id in consumer2assignment.keys():
+            if consumer_id in consumers_to_explore:
+                consumers_to_explore.remove(consumer_id)
+                for other_consumer_id in consumers_to_explore:
+                    score += abs(consumer2assignment[consumer_id] - consumer2assignment[other_consumer_id])
+        return score
+
+
+class StickyPartitionAssignor(AbstractPartitionAssignor):
+    """
+    https://cwiki.apache.org/confluence/display/KAFKA/KIP-54+-+Sticky+Partition+Assignment+Strategy
+
+    The sticky assignor serves two purposes. First, it guarantees an assignment that is as balanced as possible, meaning either:
+    - the numbers of topic partitions assigned to consumers differ by at most one; or
+    - each consumer that has 2+ fewer topic partitions than some other consumer cannot get any of those topic partitions transferred to it.
+
+    Second, it preserved as many existing assignment as possible when a reassignment occurs.
+    This helps in saving some of the overhead processing when topic partitions move from one consumer to another.
+
+    Starting fresh it would work by distributing the partitions over consumers as evenly as possible.
+    Even though this may sound similar to how round robin assignor works, the second example below shows that it is not.
+    During a reassignment it would perform the reassignment in such a way that in the new assignment
+    - topic partitions are still distributed as evenly as possible, and
+    - topic partitions stay with their previously assigned consumers as much as possible.
+
+    The first goal above takes precedence over the second one.
+
+    Example 1.
+    Suppose there are three consumers C0, C1, C2,
+    four topics t0, t1, t2, t3, and each topic has 2 partitions,
+    resulting in partitions t0p0, t0p1, t1p0, t1p1, t2p0, t2p1, t3p0, t3p1.
+    Each consumer is subscribed to all three topics.
+
+    The assignment with both sticky and round robin assignors will be:
+    - C0: [t0p0, t1p1, t3p0]
+    - C1: [t0p1, t2p0, t3p1]
+    - C2: [t1p0, t2p1]
+
+    Now, let's assume C1 is removed and a reassignment is about to happen. The round robin assignor would produce:
+    - C0: [t0p0, t1p0, t2p0, t3p0]
+    - C2: [t0p1, t1p1, t2p1, t3p1]
+
+    while the sticky assignor would result in:
+    - C0 [t0p0, t1p1, t3p0, t2p0]
+    - C2 [t1p0, t2p1, t0p1, t3p1]
+    preserving all the previous assignments (unlike the round robin assignor).
+
+
+    Example 2.
+    There are three consumers C0, C1, C2,
+    and three topics t0, t1, t2, with 1, 2, and 3 partitions respectively.
+    Therefore, the partitions are t0p0, t1p0, t1p1, t2p0, t2p1, t2p2.
+    C0 is subscribed to t0;
+    C1 is subscribed to t0, t1;
+    and C2 is subscribed to t0, t1, t2.
+
+    The round robin assignor would come up with the following assignment:
+    - C0 [t0p0]
+    - C1 [t1p0]
+    - C2 [t1p1, t2p0, t2p1, t2p2]
+
+    which is not as balanced as the assignment suggested by sticky assignor:
+    - C0 [t0p0]
+    - C1 [t1p0, t1p1]
+    - C2 [t2p0, t2p1, t2p2]
+
+    Now, if consumer C0 is removed, these two assignors would produce the following assignments.
+    Round Robin (preserves 3 partition assignments):
+    - C1 [t0p0, t1p1]
+    - C2 [t1p0, t2p0, t2p1, t2p2]
+
+    Sticky (preserves 5 partition assignments):
+    - C1 [t1p0, t1p1, t0p0]
+    - C2 [t2p0, t2p1, t2p2]
+    """
+
+    DEFAULT_GENERATION_ID = -1
+
+    name = "sticky"
+    version = 1
+
+    member_assignment: List[TopicPartition] = None
+    generation: int = DEFAULT_GENERATION_ID
+
+    _latest_partition_movements = None
+
+    @classmethod
+    def assign(cls, cluster: ClusterMetadata, members: dict):
+        """
+        Perform group assignment given cluster metadata and member subscriptions
+
+        Arguments:
+            cluster (ClusterMetadata): metadata for use in assignment
+            members (dict of {member_id: MemberMetadata}): decoded metadata for
+                each member in the group.
+
+        Returns:
+            dict: {member_id: MemberAssignment}
+        """
+        members_metadata: Dict[str, StickyAssignorMemberMetadataV1] = {}
+        for consumer, member_metadata in members.items():
+            members_metadata[consumer] = cls.parse_member_metadata(member_metadata)
+
+        executor = StickyAssignmentExecutor(cluster, members_metadata)
+        executor.perform_initial_assignment()
+        executor.balance()
+
+        cls._latest_partition_movements = executor.partition_movements
+
+        assignment = {}
+        for member_id in members:
+            assignment[member_id] = ConsumerProtocolMemberAssignment(
+                cls.version, sorted(executor.get_final_assignment(member_id)), b''
+            )
+        return assignment
+
+    @classmethod
+    def parse_member_metadata(cls, metadata) -> StickyAssignorMemberMetadataV1:
+        """
+        metadata (MemberMetadata): decoded metadata for a member of the group.
+        """
+        user_data = metadata.user_data
+        if not user_data:
+            return StickyAssignorMemberMetadataV1(
+                partitions=[], generation=cls.DEFAULT_GENERATION_ID, subscription=metadata.subscription
+            )
+
+        try:
+            decoded_user_data = StickyAssignorUserDataV1.decode(user_data)
+        except Exception as e:
+            # ignore the consumer's previous assignment if it cannot be parsed
+            log.error("Could not parse member data", e)
+            return StickyAssignorMemberMetadataV1(
+                partitions=[], generation=cls.DEFAULT_GENERATION_ID, subscription=metadata.subscription
+            )
+
+        member_partitions: List[TopicPartition] = []
+        for topic, partitions in decoded_user_data.previous_assignment:
+            member_partitions.extend([TopicPartition(topic, partition) for partition in partitions])
+        return StickyAssignorMemberMetadataV1(
+            partitions=member_partitions, generation=decoded_user_data.generation, subscription=metadata.subscription
+        )
+
+    @classmethod
+    def metadata(cls, topics):
+        if cls.member_assignment is None:
+            log.debug("No member assignment available")
+            user_data = b''
+        else:
+            log.debug(f"Member assignment is available, generating the metadata: generation {cls.generation}")
+            partitions_by_topic = defaultdict(list)
+            for topic_partition in cls.member_assignment:
+                partitions_by_topic[topic_partition.topic].append(topic_partition.partition)
+            data = StickyAssignorUserDataV1(partitions_by_topic.items(), cls.generation)
+            user_data = data.encode()
+        return ConsumerProtocolMemberMetadata(cls.version, list(topics), user_data)
+
+    @classmethod
+    def on_assignment(cls, assignment, generation: int):
+        """
+        Callback that runs on each assignment. Updates assignor's state.
+        :param generation: generation id (if present)
+        :param assignment: MemberAssignment
+        """
+        log.debug(f"On assignment: assignment={assignment}, generation={generation}")
+        cls.member_assignment: List[TopicPartition] = assignment.partitions()
+        cls.generation = generation

--- a/kafka/coordinator/assignors/sticky/sticky_assignor.py
+++ b/kafka/coordinator/assignors/sticky/sticky_assignor.py
@@ -620,6 +620,11 @@ class StickyPartitionAssignor(AbstractPartitionAssignor):
     @classmethod
     def parse_member_metadata(cls, metadata) -> StickyAssignorMemberMetadataV1:
         """
+        Parses member metadata into a python object.
+        This implementation only serializes and deserializes the StickyAssignorMemberMetadataV1 user data,
+        since no StickyAssignor written in Python was deployed ever in the wild with version V0, meaning that
+        there is no need to support backward compatibility with V0.
+
         Arguments:
           metadata (MemberMetadata): decoded metadata for a member of the group.
 

--- a/kafka/coordinator/consumer.py
+++ b/kafka/coordinator/consumer.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import time
 
+from kafka.coordinator.assignors.sticky.sticky_assignor import StickyPartitionAssignor
 from kafka.vendor import six
 
 from kafka.coordinator.base import BaseCoordinator, Generation
@@ -31,7 +32,7 @@ class ConsumerCoordinator(BaseCoordinator):
         'enable_auto_commit': True,
         'auto_commit_interval_ms': 5000,
         'default_offset_commit_callback': None,
-        'assignors': (RangePartitionAssignor, RoundRobinPartitionAssignor),
+        'assignors': (RangePartitionAssignor, RoundRobinPartitionAssignor, StickyPartitionAssignor),
         'session_timeout_ms': 10000,
         'heartbeat_interval_ms': 3000,
         'max_poll_interval_ms': 300000,
@@ -233,7 +234,7 @@ class ConsumerCoordinator(BaseCoordinator):
 
         # give the assignor a chance to update internal state
         # based on the received assignment
-        assignor.on_assignment(assignment)
+        assignor.on_assignment(assignment, generation)
 
         # reschedule the auto commit starting from now
         self.next_auto_commit_deadline = time.time() + self.auto_commit_interval

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.1-relayr"
+__version__ = "2.0.1+relayr"

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.1+relayr"
+__version__ = "2.0.1-relayr"

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,1 @@
-__version__ = '2.0.1'
+__version__ = "2.0.1-relayr"

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.1-relayr"
+__version__ = "2.0.1.relayr"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ pytest-mock==1.10.0
 sphinx-rtd-theme==0.2.4
 crc32c==1.7
 py==1.8.0
+sortedcontainers==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "sortedcontainers==2.1.0"
     ],
     extras_require={
-        "dev": [
+        "test": [
             "pytest==3.10.0",
             "pytest-cov==2.6.0",
             "lz4==2.1.2",

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import setup, Command, find_packages
 # since we can't import something we haven't built yet :)
 exec(open('kafka/version.py').read())
 
+
 class Tox(Command):
 
     user_options = []
@@ -58,5 +59,20 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
-    ]
+    ],
+    install_requires=[
+        "sortedcontainers==2.1.0"
+    ],
+    extras_require={
+        "dev": [
+            "pytest==3.10.0",
+            "pytest-cov==2.6.0",
+            "lz4==2.1.2",
+            "xxhash==1.3.0",
+            "python-snappy==0.5.3",
+            "mock==3.0.5",
+            "pytest-mock==1.10.0",
+            "crc32c==1.7",
+        ]
+    }
 )

--- a/test/test_assignors.py
+++ b/test/test_assignors.py
@@ -417,7 +417,7 @@ def test_sticky_reassignment_after_one_consumer_leaves(mocker):
 
     assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     verify_validity_and_balance(subscriptions, assignment)
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
 
 def test_sticky_reassignment_after_one_consumer_added(mocker):
@@ -440,7 +440,7 @@ def test_sticky_reassignment_after_one_consumer_added(mocker):
         )
     assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     verify_validity_and_balance(subscriptions, assignment)
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
 
 def test_sticky_same_subscriptions(mocker):
@@ -465,7 +465,7 @@ def test_sticky_same_subscriptions(mocker):
         member_metadata[member] = build_metadata(topics, assignment[member].partitions())
     assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     verify_validity_and_balance(subscriptions, assignment)
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
 
 def test_sticky_large_assignment_with_multiple_consumers_leaving(mocker):
@@ -498,7 +498,7 @@ def test_sticky_large_assignment_with_multiple_consumers_leaving(mocker):
 
     assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     verify_validity_and_balance(subscriptions, assignment)
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
 
 def test_new_subscription(mocker):
@@ -521,7 +521,7 @@ def test_new_subscription(mocker):
 
     assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     verify_validity_and_balance(subscriptions, assignment)
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
 
 def test_move_existing_assignments(mocker):
@@ -574,7 +574,7 @@ def test_stickiness(mocker):
 
     assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     verify_validity_and_balance(subscriptions, assignment)
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
     for consumer, consumer_assignment in assignment.items():
         assert (
@@ -684,7 +684,7 @@ def test_reassignment_with_random_subscriptions_and_changes(mocker, execution_nu
 
     assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     verify_validity_and_balance(subscriptions, assignment)
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
 
 def test_assignment_with_multiple_generations1(mocker):
@@ -713,7 +713,7 @@ def test_assignment_with_multiple_generations1(mocker):
     assert len(assignment2['C2'].assignment[0][1]) == 3
     assert all([partition in assignment2['C1'].assignment[0][1] for partition in assignment1['C1'].assignment[0][1]])
     assert all([partition in assignment2['C2'].assignment[0][1] for partition in assignment1['C2'].assignment[0][1]])
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
     member_metadata = {
         'C2': build_metadata({'t'}, assignment2['C2'].partitions(), 2),
@@ -724,7 +724,7 @@ def test_assignment_with_multiple_generations1(mocker):
     verify_validity_and_balance({'C2': {'t'}, 'C3': {'t'}}, assignment3)
     assert len(assignment3['C2'].assignment[0][1]) == 3
     assert len(assignment3['C3'].assignment[0][1]) == 3
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
 
 def test_assignment_with_multiple_generations2(mocker):
@@ -750,7 +750,7 @@ def test_assignment_with_multiple_generations2(mocker):
     verify_validity_and_balance({'C2': {'t'}}, assignment2)
     assert len(assignment2['C2'].assignment[0][1]) == 6
     assert all([partition in assignment2['C2'].assignment[0][1] for partition in assignment1['C2'].assignment[0][1]])
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
     member_metadata = {
         'C1': build_metadata({'t'}, assignment1['C1'].partitions(), 1),
@@ -760,7 +760,7 @@ def test_assignment_with_multiple_generations2(mocker):
 
     assignment3 = StickyPartitionAssignor.assign(cluster, member_metadata)
     verify_validity_and_balance({'C1': {'t'}, 'C2': {'t'}, 'C3': {'t'}}, assignment3)
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
     assert set(assignment3['C1'].assignment[0][1]) == set(assignment1['C1'].assignment[0][1])
     assert set(assignment3['C2'].assignment[0][1]) == set(assignment1['C2'].assignment[0][1])
     assert set(assignment3['C3'].assignment[0][1]) == set(assignment1['C3'].assignment[0][1])
@@ -786,7 +786,7 @@ def test_assignment_with_conflicting_previous_generations(mocker, execution_numb
 
     assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
     verify_validity_and_balance({'C1': {'t'}, 'C2': {'t'}, 'C3': {'t'}}, assignment)
-    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert StickyPartitionAssignor._latest_partition_movements.are_sticky()
 
 
 def make_member_metadata(subscriptions: Dict[str, Set[str]]):

--- a/test/test_assignors.py
+++ b/test/test_assignors.py
@@ -1,28 +1,45 @@
 # pylint: skip-file
 from __future__ import absolute_import
 
+from collections import defaultdict
+from random import randint, sample
+from typing import Set, Dict, List
+
 import pytest
 
+from kafka.structs import TopicPartition
 from kafka.coordinator.assignors.range import RangePartitionAssignor
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
-from kafka.coordinator.protocol import ConsumerProtocolMemberAssignment
+from kafka.coordinator.assignors.sticky.sticky_assignor import StickyPartitionAssignor, StickyAssignorUserDataV1
+from kafka.coordinator.protocol import ConsumerProtocolMemberAssignment, ConsumerProtocolMemberMetadata
 
 
-@pytest.fixture
-def cluster(mocker):
+@pytest.fixture(autouse=True)
+def reset_sticky_assignor():
+    yield
+    StickyPartitionAssignor.member_assignment = None
+    StickyPartitionAssignor.generation = -1
+
+
+def create_cluster(mocker, topics, topics_partitions=None, topic_partitions_lambda=None):
     cluster = mocker.MagicMock()
-    cluster.partitions_for_topic.return_value = set([0, 1, 2])
+    cluster.topics.return_value = topics
+    if topics_partitions is not None:
+        cluster.partitions_for_topic.return_value = topics_partitions
+    if topic_partitions_lambda is not None:
+        cluster.partitions_for_topic.side_effect = topic_partitions_lambda
     return cluster
 
 
-def test_assignor_roundrobin(cluster):
+def test_assignor_roundrobin(mocker):
     assignor = RoundRobinPartitionAssignor
 
     member_metadata = {
-        'C0': assignor.metadata(set(['t0', 't1'])),
-        'C1': assignor.metadata(set(['t0', 't1'])),
+        'C0': assignor.metadata({'t0', 't1'}),
+        'C1': assignor.metadata({'t0', 't1'}),
     }
 
+    cluster = create_cluster(mocker, {'t0', 't1'}, topics_partitions={0, 1, 2})
     ret = assignor.assign(cluster, member_metadata)
     expected = {
         'C0': ConsumerProtocolMemberAssignment(
@@ -36,14 +53,15 @@ def test_assignor_roundrobin(cluster):
         assert ret[member].encode() == expected[member].encode()
 
 
-def test_assignor_range(cluster):
+def test_assignor_range(mocker):
     assignor = RangePartitionAssignor
 
     member_metadata = {
-        'C0': assignor.metadata(set(['t0', 't1'])),
-        'C1': assignor.metadata(set(['t0', 't1'])),
+        'C0': assignor.metadata({'t0', 't1'}),
+        'C1': assignor.metadata({'t0', 't1'}),
     }
 
+    cluster = create_cluster(mocker, {'t0', 't1'}, topics_partitions={0, 1, 2})
     ret = assignor.assign(cluster, member_metadata)
     expected = {
         'C0': ConsumerProtocolMemberAssignment(
@@ -55,3 +73,812 @@ def test_assignor_range(cluster):
     assert set(ret) == set(expected)
     for member in ret:
         assert ret[member].encode() == expected[member].encode()
+
+
+def test_sticky_assignor1(mocker):
+    """
+    Given: there are three consumers C0, C1, C2,
+        four topics t0, t1, t2, t3, and each topic has 2 partitions,
+        resulting in partitions t0p0, t0p1, t1p0, t1p1, t2p0, t2p1, t3p0, t3p1.
+        Each consumer is subscribed to all three topics.
+    Then: perform fresh assignment
+    Expected: the assignment is
+    - C0: [t0p0, t1p1, t3p0]
+    - C1: [t0p1, t2p0, t3p1]
+    - C2: [t1p0, t2p1]
+    Then: remove C1 consumer and perform the reassignment
+    Expected: the new assignment is
+    - C0 [t0p0, t1p1, t2p0, t3p0]
+    - C2 [t0p1, t1p0, t2p1, t3p1]
+    """
+    cluster = create_cluster(mocker, topics={'t0', 't1', 't2', 't3'}, topics_partitions={0, 1})
+
+    subscriptions = {
+        'C0': {'t0', 't1', 't2', 't3'},
+        'C1': {'t0', 't1', 't2', 't3'},
+        'C2': {'t0', 't1', 't2', 't3'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C0': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t0', [0]), ('t1', [1]), ('t3', [0])], b''),
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t0', [1]), ('t2', [0]), ('t3', [1])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0]), ('t2', [1])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+    del subscriptions['C1']
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, sticky_assignment[member].partitions())
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C0': ConsumerProtocolMemberAssignment(
+            StickyPartitionAssignor.version, [('t0', [0]), ('t1', [1]), ('t2', [0]), ('t3', [0])], b''
+        ),
+        'C2': ConsumerProtocolMemberAssignment(
+            StickyPartitionAssignor.version, [('t0', [1]), ('t1', [0]), ('t2', [1]), ('t3', [1])], b''
+        ),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_assignor2(mocker):
+    """
+    Given: there are three consumers C0, C1, C2,
+    and three topics t0, t1, t2, with 1, 2, and 3 partitions respectively.
+    Therefore, the partitions are t0p0, t1p0, t1p1, t2p0, t2p1, t2p2.
+    C0 is subscribed to t0;
+    C1 is subscribed to t0, t1;
+    and C2 is subscribed to t0, t1, t2.
+    Then: perform the assignment
+    Expected: the assignment is
+    - C0 [t0p0]
+    - C1 [t1p0, t1p1]
+    - C2 [t2p0, t2p1, t2p2]
+    Then: remove C0 and perform the assignment
+    Expected: the assignment is
+    - C1 [t0p0, t1p0, t1p1]
+    - C2 [t2p0, t2p1, t2p2]
+    """
+
+    partitions = {'t0': {0}, 't1': {0, 1}, 't2': {0, 1, 2}}
+    cluster = create_cluster(mocker, topics={'t0', 't1', 't2'}, topic_partitions_lambda=lambda t: partitions[t])
+
+    subscriptions = {
+        'C0': {'t0'},
+        'C1': {'t0', 't1'},
+        'C2': {'t0', 't1', 't2'},
+    }
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, [])
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C0': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t0', [0])], b''),
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 1])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [0, 1, 2])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+    del subscriptions['C0']
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, sticky_assignment[member].partitions())
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t0', [0]), ('t1', [0, 1])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [0, 1, 2])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_one_consumer_no_topic(mocker):
+    cluster = create_cluster(mocker, topics={}, topics_partitions={})
+
+    subscriptions = {
+        'C': set(),
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_one_consumer_nonexisting_topic(mocker):
+    cluster = create_cluster(mocker, topics={}, topics_partitions={})
+
+    subscriptions = {
+        'C': {'t'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_one_consumer_one_topic(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0, 1, 2})
+
+    subscriptions = {
+        'C': {'t'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_should_only_assign_partitions_from_subscribed_topics(mocker):
+    cluster = create_cluster(mocker, topics={'t', 'other-t'}, topics_partitions={0, 1, 2})
+
+    subscriptions = {
+        'C': {'t'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_one_consumer_multiple_topics(mocker):
+    cluster = create_cluster(mocker, topics={'t1', 't2'}, topics_partitions={0, 1, 2})
+
+    subscriptions = {
+        'C': {'t1', 't2'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 1, 2]), ('t2', [0, 1, 2])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_two_consumers_one_topic_one_partition(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0})
+
+    subscriptions = {
+        'C1': {'t'},
+        'C2': {'t'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_two_consumers_one_topic_two_partitions(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0, 1})
+
+    subscriptions = {
+        'C1': {'t'},
+        'C2': {'t'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [1])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_multiple_consumers_mixed_topic_subscriptions(mocker):
+    partitions = {'t1': {0, 1, 2}, 't2': {0, 1}}
+    cluster = create_cluster(mocker, topics={'t1', 't2'}, topic_partitions_lambda=lambda t: partitions[t])
+
+    subscriptions = {
+        'C1': {'t1'},
+        'C2': {'t1', 't2'},
+        'C3': {'t1'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 2])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [0, 1])], b''),
+        'C3': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [1])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_add_remove_consumer_one_topic(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0, 1, 2})
+
+    subscriptions = {
+        'C1': {'t'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
+    }
+    assert_assignment(assignment, expected_assignment)
+
+    subscriptions = {
+        'C1': {'t'},
+        'C2': {'t'},
+    }
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(
+            topics, assignment[member].partitions() if member in assignment else []
+        )
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+
+    subscriptions = {
+        'C2': {'t'},
+    }
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, assignment[member].partitions())
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+    assert len(assignment['C2'].assignment[0][1]) == 3
+
+
+def test_sticky_add_remove_topic_two_consumers(mocker):
+    cluster = create_cluster(mocker, topics={'t1', 't2'}, topics_partitions={0, 1, 2})
+
+    subscriptions = {
+        'C1': {'t1'},
+        'C2': {'t1'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 2])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [1])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+    subscriptions = {
+        'C1': {'t1', 't2'},
+        'C2': {'t1', 't2'},
+    }
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, sticky_assignment[member].partitions())
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0, 2]), ('t2', [1])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [1]), ('t2', [0, 2])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+    subscriptions = {
+        'C1': {'t2'},
+        'C2': {'t2'},
+    }
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, sticky_assignment[member].partitions())
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [1])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t2', [0, 2])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_sticky_reassignment_after_one_consumer_leaves(mocker):
+    partitions = dict([(f't{i}', set(range(i))) for i in range(1, 20)])
+    cluster = create_cluster(
+        mocker, topics=set([f't{i}' for i in range(1, 20)]), topic_partitions_lambda=lambda t: partitions[t]
+    )
+
+    subscriptions = {}
+    for i in range(1, 20):
+        topics = set()
+        for j in range(1, i + 1):
+            topics.add(f't{j}')
+        subscriptions[f'C{i}'] = topics
+
+    member_metadata = make_member_metadata(subscriptions)
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+
+    del subscriptions['C10']
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, assignment[member].partitions())
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+
+def test_sticky_reassignment_after_one_consumer_added(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions=set(range(20)))
+
+    subscriptions = defaultdict(set)
+    for i in range(1, 10):
+        subscriptions[f'C{i}'] = {'t'}
+
+    member_metadata = make_member_metadata(subscriptions)
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+
+    subscriptions['C10'] = {'t'}
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(
+            topics, assignment[member].partitions() if member in assignment else []
+        )
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+
+def test_sticky_same_subscriptions(mocker):
+    partitions = dict([(f't{i}', set(range(i))) for i in range(1, 15)])
+    cluster = create_cluster(
+        mocker, topics=set([f't{i}' for i in range(1, 15)]), topic_partitions_lambda=lambda t: partitions[t]
+    )
+
+    subscriptions = defaultdict(set)
+    for i in range(1, 9):
+        for j in range(1, len(partitions.keys()) + 1):
+            subscriptions[f'C{i}'].add(f't{j}')
+
+    member_metadata = make_member_metadata(subscriptions)
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+
+    del subscriptions['C5']
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, assignment[member].partitions())
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+
+def test_sticky_large_assignment_with_multiple_consumers_leaving(mocker):
+    n_topics = 40
+    n_consumers = 200
+
+    all_topics = set([f't{i}' for i in range(1, n_topics + 1)])
+    partitions = dict([(t, set(range(1, randint(0, 10) + 1))) for t in all_topics])
+    cluster = create_cluster(mocker, topics=all_topics, topic_partitions_lambda=lambda t: partitions[t])
+
+    subscriptions = defaultdict(set)
+    for i in range(1, n_consumers + 1):
+        for j in range(0, randint(1, 20)):
+            subscriptions[f'C{i}'].add(f't{randint(1, n_topics)}')
+
+    member_metadata = make_member_metadata(subscriptions)
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, assignment[member].partitions())
+
+    for i in range(50):
+        member = f'C{randint(1, n_consumers)}'
+        if member in subscriptions:
+            del subscriptions[member]
+            del member_metadata[member]
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+
+def test_new_subscription(mocker):
+    cluster = create_cluster(mocker, topics={'t1', 't2', 't3', 't4'}, topics_partitions={0})
+
+    subscriptions = defaultdict(set)
+    for i in range(3):
+        for j in range(i, 3 * i - 2 + 1):
+            subscriptions[f'C{i}'].add(f't{j}')
+
+    member_metadata = make_member_metadata(subscriptions)
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+
+    subscriptions['C0'].add('t1')
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, [])
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+
+def test_move_existing_assignments(mocker):
+    cluster = create_cluster(mocker, topics={'t1', 't2', 't3', 't4', 't5', 't6'}, topics_partitions={0})
+
+    subscriptions = {
+        'C1': {'t1', 't2'},
+        'C2': {'t1', 't2', 't3', 't4'},
+        'C3': {'t2', 't3', 't4', 't5', 't6'},
+    }
+    member_assignments = {
+        'C1': [TopicPartition('t1', 0)],
+        'C2': [TopicPartition('t2', 0), TopicPartition('t3', 0)],
+        'C3': [TopicPartition('t4', 0), TopicPartition('t5', 0), TopicPartition('t6', 0)],
+    }
+
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, member_assignments[member])
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+
+
+def test_stickiness(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0, 1, 2})
+    subscriptions = {
+        'C1': {'t'},
+        'C2': {'t'},
+        'C3': {'t'},
+        'C4': {'t'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+    partitions_assigned = {}
+    for consumer, consumer_assignment in assignment.items():
+        assert (
+            len(consumer_assignment.partitions()) <= 1
+        ), f'Consumer {consumer} is assigned more topic partitions than expected.'
+        if len(consumer_assignment.partitions()) == 1:
+            partitions_assigned[consumer] = consumer_assignment.partitions()[0]
+
+    # removing the potential group leader
+    del subscriptions['C1']
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, assignment[member].partitions())
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+    for consumer, consumer_assignment in assignment.items():
+        assert (
+            len(consumer_assignment.partitions()) <= 1
+        ), f'Consumer {consumer} is assigned more topic partitions than expected.'
+        assert (
+            consumer not in partitions_assigned or partitions_assigned[consumer] in consumer_assignment.partitions()
+        ), f'Stickiness was not honored for consumer {consumer}'
+
+
+def test_assignment_updated_for_deleted_topic(mocker):
+    def topic_partitions(topic):
+        if topic == 't1':
+            return {0}
+        if topic == 't3':
+            return set(range(100))
+
+    cluster = create_cluster(mocker, topics={'t1', 't3'}, topic_partitions_lambda=topic_partitions)
+
+    subscriptions = {
+        'C': {'t1', 't2', 't3'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t1', [0]), ('t3', list(range(100)))], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_no_exceptions_when_only_subscribed_topic_is_deleted(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0, 1, 2})
+
+    subscriptions = {
+        'C': {'t'},
+    }
+    member_metadata = make_member_metadata(subscriptions)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0, 1, 2])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+    subscriptions = {
+        'C': {},
+    }
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, sticky_assignment[member].partitions())
+
+    cluster = create_cluster(mocker, topics={}, topics_partitions={})
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+def test_conflicting_previous_assignments(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0, 1})
+
+    subscriptions = {
+        'C1': {'t'},
+        'C2': {'t'},
+    }
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        # assume both C1 and C2 have partition 1 assigned to them in generation 1
+        member_metadata[member] = build_metadata(topics, [TopicPartition('t', 0), TopicPartition('t', 0)], 1)
+
+    sticky_assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    expected_assignment = {
+        'C1': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [0])], b''),
+        'C2': ConsumerProtocolMemberAssignment(StickyPartitionAssignor.version, [('t', [1])], b''),
+    }
+    assert_assignment(sticky_assignment, expected_assignment)
+
+
+@pytest.mark.parametrize(
+    'execution_number,n_topics,n_consumers', [(i, randint(10, 20), randint(20, 40)) for i in range(100)]
+)
+def test_reassignment_with_random_subscriptions_and_changes(mocker, execution_number, n_topics, n_consumers):
+    all_topics = set([f't{i}' for i in range(1, n_topics + 1)])
+    partitions = dict([(t, set(range(1, i + 1))) for i, t in enumerate(all_topics)])
+    cluster = create_cluster(mocker, topics=all_topics, topic_partitions_lambda=lambda t: partitions[t])
+
+    subscriptions = defaultdict(set)
+    for i in range(n_consumers):
+        topics_sample = sample(all_topics, randint(1, len(all_topics) - 1))
+        subscriptions[f'C{i}'].update(topics_sample)
+
+    member_metadata = make_member_metadata(subscriptions)
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+
+    subscriptions = defaultdict(set)
+    for i in range(n_consumers):
+        topics_sample = sample(all_topics, randint(1, len(all_topics) - 1))
+        subscriptions[f'C{i}'].update(topics_sample)
+
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, assignment[member].partitions())
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance(subscriptions, assignment)
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+
+def test_assignment_with_multiple_generations1(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0, 1, 2, 3, 4, 5})
+
+    member_metadata = {
+        'C1': build_metadata({'t'}, []),
+        'C2': build_metadata({'t'}, []),
+        'C3': build_metadata({'t'}, []),
+    }
+
+    assignment1 = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance({'C1': {'t'}, 'C2': {'t'}, 'C3': {'t'}}, assignment1)
+    assert len(assignment1['C1'].assignment[0][1]) == 2
+    assert len(assignment1['C2'].assignment[0][1]) == 2
+    assert len(assignment1['C3'].assignment[0][1]) == 2
+
+    member_metadata = {
+        'C1': build_metadata({'t'}, assignment1['C1'].partitions()),
+        'C2': build_metadata({'t'}, assignment1['C2'].partitions()),
+    }
+
+    assignment2 = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance({'C1': {'t'}, 'C2': {'t'}}, assignment2)
+    assert len(assignment2['C1'].assignment[0][1]) == 3
+    assert len(assignment2['C2'].assignment[0][1]) == 3
+    assert all([partition in assignment2['C1'].assignment[0][1] for partition in assignment1['C1'].assignment[0][1]])
+    assert all([partition in assignment2['C2'].assignment[0][1] for partition in assignment1['C2'].assignment[0][1]])
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+    member_metadata = {
+        'C2': build_metadata({'t'}, assignment2['C2'].partitions(), 2),
+        'C3': build_metadata({'t'}, assignment1['C3'].partitions(), 1),
+    }
+
+    assignment3 = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance({'C2': {'t'}, 'C3': {'t'}}, assignment3)
+    assert len(assignment3['C2'].assignment[0][1]) == 3
+    assert len(assignment3['C3'].assignment[0][1]) == 3
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+
+def test_assignment_with_multiple_generations2(mocker):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0, 1, 2, 3, 4, 5})
+
+    member_metadata = {
+        'C1': build_metadata({'t'}, []),
+        'C2': build_metadata({'t'}, []),
+        'C3': build_metadata({'t'}, []),
+    }
+
+    assignment1 = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance({'C1': {'t'}, 'C2': {'t'}, 'C3': {'t'}}, assignment1)
+    assert len(assignment1['C1'].assignment[0][1]) == 2
+    assert len(assignment1['C2'].assignment[0][1]) == 2
+    assert len(assignment1['C3'].assignment[0][1]) == 2
+
+    member_metadata = {
+        'C2': build_metadata({'t'}, assignment1['C2'].partitions(), 1),
+    }
+
+    assignment2 = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance({'C2': {'t'}}, assignment2)
+    assert len(assignment2['C2'].assignment[0][1]) == 6
+    assert all([partition in assignment2['C2'].assignment[0][1] for partition in assignment1['C2'].assignment[0][1]])
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+    member_metadata = {
+        'C1': build_metadata({'t'}, assignment1['C1'].partitions(), 1),
+        'C2': build_metadata({'t'}, assignment2['C2'].partitions(), 2),
+        'C3': build_metadata({'t'}, assignment1['C3'].partitions(), 1),
+    }
+
+    assignment3 = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance({'C1': {'t'}, 'C2': {'t'}, 'C3': {'t'}}, assignment3)
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+    assert set(assignment3['C1'].assignment[0][1]) == set(assignment1['C1'].assignment[0][1])
+    assert set(assignment3['C2'].assignment[0][1]) == set(assignment1['C2'].assignment[0][1])
+    assert set(assignment3['C3'].assignment[0][1]) == set(assignment1['C3'].assignment[0][1])
+
+
+@pytest.mark.parametrize('execution_number', range(50))
+def test_assignment_with_conflicting_previous_generations(mocker, execution_number):
+    cluster = create_cluster(mocker, topics={'t'}, topics_partitions={0, 1, 2, 3, 4, 5})
+
+    member_assignments = {
+        'C1': [TopicPartition('t', p) for p in {0, 1, 4}],
+        'C2': [TopicPartition('t', p) for p in {0, 2, 3}],
+        'C3': [TopicPartition('t', p) for p in {3, 4, 5}],
+    }
+    member_generations = {
+        'C1': 1,
+        'C2': 1,
+        'C3': 2,
+    }
+    member_metadata = {}
+    for member in member_assignments.keys():
+        member_metadata[member] = build_metadata({'t'}, member_assignments[member], member_generations[member])
+
+    assignment = StickyPartitionAssignor.assign(cluster, member_metadata)
+    verify_validity_and_balance({'C1': {'t'}, 'C2': {'t'}, 'C3': {'t'}}, assignment)
+    assert StickyPartitionAssignor._latest_partition_movements.is_sticky()
+
+
+def make_member_metadata(subscriptions: Dict[str, Set[str]]):
+    member_metadata = {}
+    for member, topics in subscriptions.items():
+        member_metadata[member] = build_metadata(topics, [])
+    return member_metadata
+
+
+def build_metadata(topics, member_assignment_partitions, generation=-1):
+    partitions_by_topic = defaultdict(list)
+    for topic_partition in member_assignment_partitions:
+        partitions_by_topic[topic_partition.topic].append(topic_partition.partition)
+    data = StickyAssignorUserDataV1(partitions_by_topic.items(), generation)
+    user_data = data.encode()
+    return ConsumerProtocolMemberMetadata(StickyPartitionAssignor.version, list(topics), user_data)
+
+
+def assert_assignment(result_assignment, expected_assignment):
+    assert result_assignment == expected_assignment
+    assert set(result_assignment) == set(expected_assignment)
+    for member in result_assignment:
+        assert result_assignment[member].encode() == expected_assignment[member].encode()
+
+
+def verify_validity_and_balance(subscriptions: Dict[str, Set[str]], assignment):
+    """
+    Verifies that the given assignment is valid with respect to the given subscriptions
+    Validity requirements:
+    - each consumer is subscribed to topics of all partitions assigned to it, and
+    - each partition is assigned to no more than one consumer
+    Balance requirements:
+    - the assignment is fully balanced (the numbers of topic partitions assigned to consumers differ by at most one), or
+    - there is no topic partition that can be moved from one consumer to another with 2+ fewer topic partitions
+
+    :param subscriptions  topic subscriptions of each consumer
+    :param assignment: given assignment for balance check
+    """
+    assert subscriptions.keys() == assignment.keys()
+
+    consumers = sorted(list(assignment.keys()))
+    for i in range(len(consumers)):
+        consumer = consumers[i]
+        partitions = assignment[consumer].partitions()
+        for partition in partitions:
+            assert partition.topic in subscriptions[consumer], (
+                f'Error: Partition {partition} is assigned to consumer {consumers[i]}, '
+                f'but it is not subscribed to topic {partition.topic}\n'
+                f'Subscriptions: {subscriptions}\n'
+                f'Assignments: {assignment}'
+            )
+        if i == len(consumers) - 1:
+            continue
+
+        for j in range(i + 1, len(consumers)):
+            other_consumer = consumers[j]
+            other_partitions = assignment[other_consumer].partitions()
+            partitions_intersection = set(partitions).intersection(set(other_partitions))
+            assert partitions_intersection == set(), (
+                f'Error: Consumers {consumer} and {other_consumer} have common partitions '
+                f'assigned to them: {partitions_intersection}\n'
+                f'Subscriptions: {subscriptions}\n'
+                f'Assignments: {assignment}'
+            )
+
+            if abs(len(partitions) - len(other_partitions)) <= 1:
+                continue
+
+            assignments_by_topic = group_partitions_by_topic(partitions)
+            other_assignments_by_topic = group_partitions_by_topic(other_partitions)
+            if len(partitions) > len(other_partitions):
+                for topic in assignments_by_topic.keys():
+                    assert topic not in other_assignments_by_topic, (
+                        f'Error: Some partitions can be moved from {consumer} ({len(partitions)} partitions) '
+                        f'to {other_consumer} ({len(other_partitions)} partitions) '
+                        f'to achieve a better balance\n'
+                        f'Subscriptions: {subscriptions}\n'
+                        f'Assignments: {assignment}'
+                    )
+            if len(other_partitions) > len(partitions):
+                for topic in other_assignments_by_topic.keys():
+                    assert topic not in assignments_by_topic, (
+                        f'Error: Some partitions can be moved from {other_consumer} ({len(other_partitions)} partitions) '
+                        f'to {consumer} ({len(partitions)} partitions) '
+                        f'to achieve a better balance\n'
+                        f'Subscriptions: {subscriptions}\n'
+                        f'Assignments: {assignment}'
+                    )
+
+
+def group_partitions_by_topic(partitions: List[TopicPartition]) -> Dict[str, Set[int]]:
+    result = defaultdict(set)
+    for p in partitions:
+        result[p.topic].add(p.partition)
+    return result

--- a/test/test_coordinator.py
+++ b/test/test_coordinator.py
@@ -9,6 +9,7 @@ from kafka.consumer.subscription_state import (
     SubscriptionState, ConsumerRebalanceListener)
 from kafka.coordinator.assignors.range import RangePartitionAssignor
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
+from kafka.coordinator.assignors.sticky.sticky_assignor import StickyPartitionAssignor
 from kafka.coordinator.base import Generation, MemberState, HeartbeatThread
 from kafka.coordinator.consumer import ConsumerCoordinator
 from kafka.coordinator.protocol import (
@@ -77,6 +78,10 @@ def test_group_protocols(coordinator):
             RoundRobinPartitionAssignor.version,
             ['foobar'],
             b'')),
+        ('sticky', ConsumerProtocolMemberMetadata(
+            StickyPartitionAssignor.version,
+            ['foobar'],
+            b'')),
     ]
 
 
@@ -95,7 +100,7 @@ def test_pattern_subscription(coordinator, api_version):
         [(0, 'fizz', []),
          (0, 'foo1', [(0, 0, 0, [], [])]),
          (0, 'foo2', [(0, 0, 1, [], [])])]))
-    assert coordinator._subscription.subscription == set(['foo1', 'foo2'])
+    assert coordinator._subscription.subscription == {'foo1', 'foo2'}
 
     # 0.9 consumers should trigger dynamic partition assignment
     if api_version >= (0, 9):
@@ -103,14 +108,14 @@ def test_pattern_subscription(coordinator, api_version):
 
     # earlier consumers get all partitions assigned locally
     else:
-        assert set(coordinator._subscription.assignment.keys()) == set([
-            TopicPartition('foo1', 0),
-            TopicPartition('foo2', 0)])
+        assert set(coordinator._subscription.assignment.keys()) == {TopicPartition('foo1', 0),
+                                                                    TopicPartition('foo2', 0)}
 
 
 def test_lookup_assignor(coordinator):
     assert coordinator._lookup_assignor('roundrobin') is RoundRobinPartitionAssignor
     assert coordinator._lookup_assignor('range') is RangePartitionAssignor
+    assert coordinator._lookup_assignor('sticky') is StickyPartitionAssignor
     assert coordinator._lookup_assignor('foobar') is None
 
 
@@ -124,7 +129,7 @@ def test_join_complete(mocker, coordinator):
     coordinator._on_join_complete(
         0, 'member-foo', 'roundrobin', assignment.encode())
     assert assignor.on_assignment.call_count == 1
-    assignor.on_assignment.assert_called_with(assignment)
+    assignor.on_assignment.assert_called_with(assignment, 0)
 
 
 def test_subscription_listener(mocker, coordinator):
@@ -141,9 +146,7 @@ def test_subscription_listener(mocker, coordinator):
     coordinator._on_join_complete(
         0, 'member-foo', 'roundrobin', assignment.encode())
     assert listener.on_partitions_assigned.call_count == 1
-    listener.on_partitions_assigned.assert_called_with(set([
-        TopicPartition('foobar', 0),
-        TopicPartition('foobar', 1)]))
+    listener.on_partitions_assigned.assert_called_with({TopicPartition('foobar', 0), TopicPartition('foobar', 1)})
 
 
 def test_subscription_listener_failure(mocker, coordinator):

--- a/test/test_partition_movements.py
+++ b/test/test_partition_movements.py
@@ -1,0 +1,23 @@
+from kafka.structs import TopicPartition
+
+from kafka.coordinator.assignors.sticky.partition_movements import PartitionMovements
+
+
+def test_empty_movements_are_sticky():
+    partition_movements = PartitionMovements()
+    assert partition_movements.are_sticky()
+
+
+def test_sticky_movements():
+    partition_movements = PartitionMovements()
+    partition_movements.move_partition(TopicPartition('t', 1), 'C1', 'C2')
+    partition_movements.move_partition(TopicPartition('t', 1), 'C2', 'C3')
+    partition_movements.move_partition(TopicPartition('t', 1), 'C3', 'C1')
+    assert partition_movements.are_sticky()
+
+
+def test_should_detect_non_sticky_assignment():
+    partition_movements = PartitionMovements()
+    partition_movements.move_partition(TopicPartition('t', 1), 'C1', 'C2')
+    partition_movements.move_partition(TopicPartition('t', 2), 'C2', 'C1')
+    assert not partition_movements.are_sticky()


### PR DESCRIPTION
JIRA: https://relayr.atlassian.net/browse/C20-5361 
Implementation of a sticky partition assignment strategy for kafka consumers.
Motivation: https://relayr.atlassian.net/browse/C20-5310

General motivation behind sticky assignment:
> In certain circumstances the round robin assignor, [...], fails to produce an optimal and balanced assignment of topic partitions to consumers. [...] In addition, when a reassignment occurs, none of the existing strategies consider what topic partition assignments were before reassignment, as if they are about to perform a fresh assignment. Preserving the existing assignments could reduce some of the overheads of a reassignment. For example, Kafka consumers retain pre-fetched messages for partitions assigned to them before a reassignment. Therefore, preserving the partition assignment could save on the number of messages delivered to consumers after a reassignment. Another advantage would be reducing the need to cleanup local partition state between rebalances.

### Approach
The assignment algorithm is described here: [KIP-54](https://cwiki.apache.org/confluence/display/KAFKA/KIP-54+-+Sticky+Partition+Assignment+Strategy)
And original java implementation is here: [AbstractStickyAssignor.java](https://github.com/a0x8o/kafka/blob/master/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java) + [StickyAssignor.java](https://github.com/a0x8o/kafka/blob/master/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java)

The tests are mirrored from here [AbstractStickyAssignorTest.java](https://github.com/a0x8o/kafka/blob/de9a5e62076e107824d815c7a26303ee1c57e26f/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java) and here [StickyAssignorTest.java](https://github.com/a0x8o/kafka/blob/a2110b5aaa9f6cd082e9807124f0d6d3f38d1fcb/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java)

Very few adjustments are made to the original logic to avoid introducing unnecessary bugs. The adjustments in place related to the use of python-specific structures (like `SortedSet` and `defaultdict`)

### QA
Adjusted consumer tests to include the new assignor
Added tests to cover assignment logic

Notes: tests do _not_ follow our usual naming conventions, but mirror tests from the java client.

### Entry point 
[KIP-54](https://cwiki.apache.org/confluence/display/KAFKA/KIP-54+-+Sticky+Partition+Assignment+Strategy)
`sticky_assignor.py`